### PR TITLE
Dao heitettyjen poikkeusten muuttaminen tarkemmiksi ja yleisesti poikkeuksista. ChooseAddScene catch:ssä null errorMsg kutsuminen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin
 *.db
 .DS_Store
 :test:
+/.nb-gradle/

--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ Etusivulla paina Tallennetut URLit -nappia. Selausnäkymässä voit painaa Takai
 URLien tiedot on listattuna niin, että yhdellä rivillä on yhden URLin tiedot, ensiksi otsikko ja toiseksi itse URL. Jokaisen URLin jälkeen on myös Kopioi-nappi, jonka avulla URLin voi kopioida koneen leikepöydälle ja sieltä kätevästi liittää esimerkiksi selaimella osoitekenttään. Kun kopioit URLin onnistuneesti, sivun yläosaan ilmestyy teksti "URL kopioitu leikepöydälle!" varmitukseksi siitä, että kopiointi onnistui.
 
 Hakutuloksia voi suodattaa tietyn kentän perusteella valitsemalla suodatin vetolaatikosta, ja kirjottamalla hakukenttään etsittävä avainsana.
+

--- a/src/main/java/Database/DbConnection.java
+++ b/src/main/java/Database/DbConnection.java
@@ -18,7 +18,7 @@ public class DbConnection {
         createDbIfNotExists();
     }
 
-    public Connection getConnection() throws Exception {
+    public Connection getConnection() throws SQLException {
         if (this.connection == null) {
             this.connect();
         }

--- a/src/main/java/Database/SqlDbBookDao.java
+++ b/src/main/java/Database/SqlDbBookDao.java
@@ -15,12 +15,12 @@ public class SqlDbBookDao implements BookDao {
     private Connection connection;
     private ArrayList<Book> bookList;
 
-    public SqlDbBookDao(String dbFile) throws Exception {
+    public SqlDbBookDao(String dbFile) throws SQLException {
         this.db = new DbConnection(dbFile);
         this.connection = db.getConnection();
     }
 
-    public SqlDbBookDao() throws Exception {
+    public SqlDbBookDao() throws SQLException {
         this("jdbc:sqlite:lukuvinkit.db");
     }
 

--- a/src/main/java/Database/SqlDbMovieDao.java
+++ b/src/main/java/Database/SqlDbMovieDao.java
@@ -16,12 +16,12 @@ public class SqlDbMovieDao implements MovieDao {
     private Connection connection;
     private ArrayList<Movie> movieList;
 
-    public SqlDbMovieDao(String dbFile) throws Exception {
+    public SqlDbMovieDao(String dbFile) throws SQLException {
         this.db = new DbConnection(dbFile);
         this.connection = db.getConnection();
     }
 
-    public SqlDbMovieDao() throws Exception {
+    public SqlDbMovieDao() throws SQLException {
         this("jdbc:sqlite:lukuvinkit.db");
     }
 

--- a/src/main/java/Database/SqlDbUrlDao.java
+++ b/src/main/java/Database/SqlDbUrlDao.java
@@ -14,12 +14,12 @@ public class SqlDbUrlDao implements UrlDao {
     private Connection connection;
     private ArrayList<Url> urlList;
 
-    public SqlDbUrlDao(String dbFile) throws Exception {
+    public SqlDbUrlDao(String dbFile) throws SQLException {
         this.db = new DbConnection(dbFile);
         this.connection = db.getConnection();
     }
 
-    public SqlDbUrlDao() throws Exception {
+    public SqlDbUrlDao() throws SQLException {
         this("jdbc:sqlite:lukuvinkit.db");
     }
 

--- a/src/main/java/Scenes/ChooseAddScene.java
+++ b/src/main/java/Scenes/ChooseAddScene.java
@@ -12,6 +12,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import java.sql.SQLException;
 
 public class ChooseAddScene {
 
@@ -34,7 +35,8 @@ public class ChooseAddScene {
         try {
             vinkkiService = new VinkkiService(new SqlDbBookDao(),
                 new SqlDbUrlDao(), new SqlDbMovieDao());
-        } catch (Exception e) {
+        } catch (SQLException e) {
+            errorMsg = new Label();
             errorMsg.setText("Error in database connection: " + e.getMessage());
         }
 


### PR DESCRIPTION
Dao exceptionit tarkemmiksi SQLException tyyppisiksi. Yleisen exceptionin heittely ja kiinniottelu huono käytäntö. Tästä tapauksessa sitä ei välttämättä näe niin hyvin, mutta sillä ChooseAddScene konstruktorin poikkeuksen käsittelyssä selvästi oletetaan, että käsitellään SQLException, niin pitäisi myös ottaa kiinni SQLException. Nyt voisi olla mahdollista, että tuo ottaakin kiinni jonkun muun exceptionin (Vaikkakin tosiaan näin pienessä mittakaavassa epätodennäköistä), jolloin käsittely tuottaa hämäävän virheviestin.

Itse käsittelyssä kutsutaan null olevan errorMsg metodia. 

Samalla kysymys siitä miten teette tuon virheenkäsittelyn? Nyt vaikuttaisi siltä, että virhe vaan otetaan ylös ja jatketaan matkaa. Voiko aiheuttaa myöhemmin suorituksessa epämääräisiä ongelmia?